### PR TITLE
Rewrite to wrap the whole argparse interface

### DIFF
--- a/src/ffq_api/app.py
+++ b/src/ffq_api/app.py
@@ -1,12 +1,24 @@
 # uvicorn ffq_api.app:app --reload
 
+import argparse
+from enum import Enum
 import re
 from typing import Union
 
 from fastapi import FastAPI, Request
 from ffq import main as ffq_main
 
+# Build an Enum class for FastAPI that dynamically
+# contains the ffq SEARCH_TYPES
+class TempEnum(str, Enum):
+    pass
+
+
+Search_Types = TempEnum("Search_Types", {st: st for st in ffq_main.SEARCH_TYPES})
+
+# Initialise the FastAPI app
 app = FastAPI()
+
 
 @app.get("/")
 def read_root(request: Request):
@@ -17,19 +29,27 @@ def read_root(request: Request):
 
 
 @app.get("/v1alpha1/{accession_str}")
-def read_item(accession_str: str, aws: bool = False):
-    accession_strs = re.split(';| |,', accession_str)
-    accessions = ffq_main.validate_accessions(accession_strs, ffq_main.SEARCH_TYPES)
-    results = []
-    for v in accessions:
-        results.append(ffq_main.FFQ[v["prefix"]](v["accession"], 0))
-    results
+def read_item(
+    accession_str: str,
+    search_type: Union[Search_Types, None] = None,
+    ftp: bool = False,
+    aws: bool = False,
+    gcp: bool = False,
+    ncbi: bool = False,
+    level: Union[int, None] = None,
+):
+    accessions = re.split(";| |,", accession_str)
 
-    keyed = {result["accession"]: result for result in results}
-    links = []
-    if aws:
-        # get run files
-        found_links = []
-        ffq_main.findkey(keyed, "aws", found_links)
-        links += found_links
-    return links if len(links) else keyed
+    args = argparse.Namespace()
+    args.IDs = accessions  # One or multiple SRA / GEO / ENCODE / ENA / EBI-EMBL / DDBJ / Biosample accessions DOIs, or paper titles
+    args.o = None  # Path to write metadata (default: standard out)
+    args.t = search_type
+    args.l = level  # Max depth to fetch data within accession tree
+    args.ftp = ftp  # Return FTP links
+    args.aws = aws  # Return AWS links
+    args.gcp = gcp  # Return GCP links
+    args.ncbi = ncbi  # Return NCBI links
+    args.split = False  # Split output into separate files by accession
+    args.verbose = False  # Print debugging information
+
+    return ffq_main.run_ffq(args)


### PR DESCRIPTION
Rewrite the API to call the entire `ffq` command line tool, instead of just some of the internal functionality.

Should address #3 as this approach mirrors command-line execution completely, so should be feature complete.

For this code to work, we need some very tiny changes to the upstream `ffq` package. These have no effect on the functionality of the command line tool itself. All I'm doing here is splitting the main function into two so that we can run it without the command-line `argparse` calls:

<details>

<summary><code>git diff</code></summary>

```diff
diff --git a/ffq/main.py b/ffq/main.py
index 80b6c2e..a9e9c4a 100644
--- a/ffq/main.py
+++ b/ffq/main.py
@@ -55,7 +55,7 @@ FFQ.update({t: ffq_bioproject for t in BIOPROJECT_TYPES})
 FFQ.update({t: ffq_biosample for t in BIOSAMPLE_TYPES})
 
 
-def main():
+def cli():
     """Command-line entrypoint.
     """
     # Main parser
@@ -138,6 +138,14 @@ def main():
 
     args = parser.parse_args()
 
+    try:
+        print(json.dumps(run_ffq(args), indent=4))
+    except UserWarning as e:
+        parser.error(e)
+
+
+def run_ffq(args):
+
     logging.basicConfig(
         format='[%(asctime)s] %(levelname)7s %(message)s',
         level=logging.DEBUG if args.verbose else logging.INFO,
@@ -150,16 +158,16 @@ def main():
 
     # Check the -o is provided if --split is set
     if args.split and not args.o:
-        parser.error('`-o` must be provided when using `--split`')
+        raise UserWarning('`-o` must be provided when using `--split`')
 
     if args.l:
         if ([args.ftp, args.ncbi, args.gcp, args.aws]).count(True) > 0:
-            parser.error("`-l` is not compatible with link fetching.")
+            raise UserWarning("`-l` is not compatible with link fetching.")
         if args.l <= 0:  # noqa
-            parser.error('level `-l` must greater than zero')
+            raise UserWarning('level `-l` must greater than zero')
     if args.t:
         if args.t not in SEARCH_TYPES:
-            parser.error(
+            raise UserWarning(
                 f"{args.t} is not a valide type. TYPES can be one of {', '.join(SEARCH_TYPES)}"
             )
 
@@ -169,16 +177,16 @@ def main():
     # check if accessions are valid (TODO separate cleaning accessions and checking them)
     for v in accessions:
         if v["prefix"] in ENCODE_TYPES and args.split:
-            parser.error(
+            raise UserWarning(
                 "`--split` is currently not compatible with ENCODE accessions"
             )
         if v["prefix"] in ENCODE_TYPES and ([args.ftp, args.aws, args.gcp,
                                              args.ncbi]).count(True) > 0:
-            parser.error(
+            raise UserWarning(
                 "Direct link fetching is currently not compatible with ENCODE accessions"
             )
         if v["valid"] is False:
-            parser.error(
+            raise UserWarning(
                 f"{v['accession']} is not a valid ID. IDs can be one of {', '.join(SEARCH_TYPES)}"  # noqa
             )
             sys.exit(1)
@@ -251,4 +259,4 @@ def main():
             with open(args.o, 'w') as f:
                 json.dump(keyed, f, indent=4)
     else:
-        print(json.dumps(keyed, indent=4))
+        return keyed
diff --git a/setup.py b/setup.py
index 657698c..9634fe7 100644
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     install_requires=read('requirements.txt').strip().split('\n'),
     entry_points={
-        'console_scripts': ['ffq=ffq.main:main'],
+        'console_scripts': ['ffq=ffq.main:cli'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',

```

</details>

If we're happy with this approach then I can push a PR to the `ffq` repo with these changes and explain what we're building here.