### PR TITLE
Use `ffq` development branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     fastapi>=0.68.0
     pydantic>=1.8.0
     uvicorn>=0.15.0
-    ffq>=0.2.1
+    git+https://github.com/pachterlab/ffq@devel
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Changes package config to use the `devel` branch of `ffq` which contains Phil's fixes. Should resolve #3 and #6 for now. Just a temporary solution until the ffq devs make a new release.