### PR TITLE
Update query endpoint to match CLI

### DIFF
--- a/src/ffq_api/app.py
+++ b/src/ffq_api/app.py
@@ -11,13 +11,13 @@ from . import __version__
 from ffq import __version__ as ffq_version
 from ffq import main as ffq_main
 
-# Build an Enum class for FastAPI that dynamically
-# contains the ffq SEARCH_TYPES
-class TempEnum(str, Enum):
+
+# Define an Enum class for FastAPI that contains the ffq SEARCH_TYPES
+class NamedEnum(str, Enum):
     pass
 
+SearchTypes = NamedEnum("SearchTypes", {st: st for st in ffq_main.SEARCH_TYPES})
 
-Search_Types = TempEnum("Search_Types", {st: st for st in ffq_main.SEARCH_TYPES})
 
 # Initialise the FastAPI app
 app = FastAPI()
@@ -38,47 +38,63 @@ def read_root(request: Request):
 @app.get("/v1alpha1/{accession_str}")
 def read_item(
     accession_str: str,
-    search_type: Union[Search_Types, None] = None,
+    search_type: Union[SearchTypes, None] = None,
     ftp: bool = False,
     aws: bool = False,
     gcp: bool = False,
     ncbi: bool = False,
     level: Union[int, None] = None,
 ):
+    """
+    Perform a query with ffq.
+
+    :param accession_str: One or multiple SRA / GEO / ENCODE / ENA / EBI-EMBL / DDBJ / Biosample accessions, DOIs, or paper titles
+    :param search_type:
+    :param ftp:           Return FTP links
+    :param aws:           Return AWS links
+    :param gcp:           Return GCP links
+    :param ncbi:          Return NCBI links
+    :param level:         Max depth to fetch data within accession tree
+    """
     request_start = datetime.now()
-    accessions = re.split(";| |,", accession_str)
 
+    # Parse arguments
     args = argparse.Namespace()
-    args.IDs = accessions  # One or multiple SRA / GEO / ENCODE / ENA / EBI-EMBL / DDBJ / Biosample accessions DOIs, or paper titles
-    args.o = None  # Path to write metadata (default: standard out)
+    args.IDs = re.split(";| |,", accession_str)
+    args.o = None
     args.t = search_type
-    args.l = level  # Max depth to fetch data within accession tree
-    args.ftp = ftp  # Return FTP links
-    args.aws = aws  # Return AWS links
-    args.gcp = gcp  # Return GCP links
-    args.ncbi = ncbi  # Return NCBI links
-    args.split = False  # Split output into separate files by accession
-    args.verbose = False  # Print debugging information
+    args.l = level
+    args.ftp = ftp
+    args.aws = aws
+    args.gcp = gcp
+    args.ncbi = ncbi
+    args.split = False
+    args.verbose = False
 
+    # Perform query
     results = ffq_main.run_ffq(args)
-    request_finish = datetime.now()
-    results["meta"] = {
-        "ffq_api_version": __version__,
-        "ffq_version": ffq_version,
-        "query": {
-            "IDs": accession_str,
-            "search_type": search_type,
-            "level": level,
-            "ftp": ftp,
-            "aws": aws,
-            "gcp": gcp,
-            "ncbi": ncbi,
-        },
-        "request": {
-            "start": request_start.isoformat(),
-            "finish": request_finish.isoformat(),
-            "duration_seconds": (request_finish - request_start).total_seconds(),
-        },
-    }
 
-    return results
+    request_finish = datetime.now()
+
+    # Return API response
+    return {
+        "results": results,
+        "meta": {
+            "ffq_api_version": __version__,
+            "ffq_version": ffq_version,
+            "query": {
+                "IDs": accession_str,
+                "search_type": search_type,
+                "level": level,
+                "ftp": ftp,
+                "aws": aws,
+                "gcp": gcp,
+                "ncbi": ncbi,
+            },
+            "request": {
+                "start": request_start.isoformat(),
+                "finish": request_finish.isoformat(),
+                "duration_seconds": (request_finish - request_start).total_seconds(),
+            },
+        }
+    }


### PR DESCRIPTION
Closes #3 

This PR changes the API response so that the CLI results are embedded in the response object. The reason is that ffq returns only the list of links if one of the options like `aws`, `gcp`, etc are enabled. Both the library and CLI have this behavior.

I'm hesitant to merge this PR though because I don't think it's what users expect. So I think we should do one of the following first:
- get the ffq devs to fix this behavior
- call ffq multiple times and merge the partial results